### PR TITLE
fix: added a sending state

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -19,6 +19,7 @@ export const getMessages = query({
         userId: undefined,
         from: await ctx.table("users").getX(message.userId),
         readBy: await message.edge("readBy"),
+        sent: true,
       }));
   },
 });

--- a/src/app/(internal-sites)/chats/[chatId]/page.tsx
+++ b/src/app/(internal-sites)/chats/[chatId]/page.tsx
@@ -107,6 +107,7 @@ export default function Page({ params }: { params: { chatId: string } }) {
         privateChatId: chatId,
         from: userInfo,
         readBy: [userInfo],
+        sent: false,
       };
       localStore.setQuery(api.messages.getMessages, { chatId }, [
         ...existingMessages,

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -76,7 +76,7 @@ export const Message = ({
   const markRead = useMutation(api.messages.markMessageRead);
 
   useEffect(() => {
-    if (inView) {
+    if (inView && message.sent) {
       markRead({ messageId: message._id });
     }
   }, [inView, message._id, message.deleted, deleteMessage]);

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -136,9 +136,9 @@ export const Message = ({
                   ? message.readBy.map((user) =>
                       user.username != clerkUser.user?.username
                         ? "Read"
-                        : message.readBy.length == 1
+                        : message.sent
                           ? "Sent"
-                          : null,
+                          : "Sending",
                     )
                   : null
                 : null}


### PR DESCRIPTION
With the introduction of optimistic updates, messages are displayed that have not yet received the convex server. This is why we need to display that properly in the UI