### PR TITLE
fix: fix all problems with the request of clearing a chat

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,8 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as chats from "../chats.js";
+import type * as clearRequests from "../clearRequests.js";
+import type * as crons from "../crons.js";
 import type * as lib_functions from "../lib/functions.js";
 import type * as lib_types from "../lib/types.js";
 import type * as messages from "../messages.js";
@@ -29,6 +31,8 @@ import type * as users from "../users.js";
  */
 declare const fullApi: ApiFromModules<{
   chats: typeof chats;
+  clearRequests: typeof clearRequests;
+  crons: typeof crons;
   "lib/functions": typeof lib_functions;
   "lib/types": typeof lib_types;
   messages: typeof messages;

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -141,6 +141,8 @@ export const getChats = query({
         let firstReadMessageIndex = -1;
         for (let i = 0; i < sortedMessages.length; i++) {
           const message = sortedMessages[i];
+          if (!message) continue;
+          
           if (
             (message.type === "message" && message.deleted) ||
             (message.type !== "message" &&

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -124,8 +124,7 @@ export const getChats = query({
           .map(async (request) => {
             return {
               ...request,
-              // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- ESLint rule is broken
-              type: `${request.status}Request` as `${Infer<typeof status>}Request`,
+              type: `${request.status}Request` satisfies `${Infer<typeof status>}Request`,
               clerkId: (await ctx.table("users").getX(request.userId)).clerkId,
             };
           });

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -1,6 +1,5 @@
 import { mutation, query } from "./lib/functions";
-import { ConvexError, type Infer, v } from "convex/values";
-import { type status } from "./schema";
+import { ConvexError, v } from "convex/values";
 
 export const createChat = mutation({
   args: { friendsUsername: v.string(), friendsUsernameId: v.string() },
@@ -124,7 +123,7 @@ export const getChats = query({
           .map(async (request) => {
             return {
               ...request,
-              type: `${request.status}Request` satisfies `${Infer<typeof status>}Request`,
+              type: `${request.status}Request` as const,
               clerkId: (await ctx.table("users").getX(request.userId)).clerkId,
             };
           });
@@ -141,7 +140,7 @@ export const getChats = query({
         for (let i = 0; i < sortedMessages.length; i++) {
           const message = sortedMessages[i];
           if (!message) continue;
-          
+
           if (
             (message.type === "message" && message.deleted) ||
             (message.type !== "message" &&

--- a/convex/chats.ts
+++ b/convex/chats.ts
@@ -105,7 +105,7 @@ export const getChats = query({
       return null;
     }
 
-    return await ctx
+    return ctx
       .table("users")
       .getX("clerkId", identity.tokenIdentifier)
       .edge("privateChats")

--- a/convex/clearRequests.ts
+++ b/convex/clearRequests.ts
@@ -1,0 +1,173 @@
+import { internalMutation, mutation } from "./lib/functions";
+import { ConvexError, v } from "convex/values";
+
+export const createClearRequest = mutation({
+  args: { chatId: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+
+    if (identity === null) {
+      console.error("Unauthenticated call to mutation");
+      return null;
+    }
+
+    const convexUser = await ctx
+      .table("users")
+      .get("clerkId", identity.tokenIdentifier);
+
+    const parsedChatId = ctx.table("privateChats").normalizeId(args.chatId);
+
+    if (!parsedChatId) {
+      throw new ConvexError("chatId was invalid");
+    }
+
+    if (!convexUser) {
+      throw new ConvexError(
+        "Mismatch between Clerk and Convex. This is an error by us.",
+      );
+    }
+
+    const usersInChat = await ctx
+      .table("privateChats")
+      .getX(parsedChatId)
+      .edge("users");
+
+    if (
+      !usersInChat.some((user) => user.clerkId === identity.tokenIdentifier)
+    ) {
+      throw new ConvexError(
+        "UNAUTHORIZED REQUEST: User tried to create a request in a chat in which he is not in.",
+      );
+    }
+
+    const openRequests = await ctx
+      .table("privateChats")
+      .get(parsedChatId)
+      .edge("clearRequests")
+      .filter((q) => q.eq(q.field("status"), "pending"));
+
+    if (openRequests && openRequests?.length > 0) {
+      throw new ConvexError("There is already at least one open request.");
+    }
+
+    await ctx.table("clearRequests").insert({
+      userId: convexUser._id,
+      privateChatId: parsedChatId,
+      status: "pending",
+    });
+  },
+});
+
+export const rejectClearRequest = mutation({
+  args: { requestId: v.string(), chatId: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+
+    if (identity === null) {
+      console.error("Unauthenticated call to mutation");
+      return null;
+    }
+
+    const parsedRequestId = ctx
+      .table("clearRequests")
+      .normalizeId(args.requestId);
+
+    if (!parsedRequestId) {
+      throw new ConvexError("chatId was invalid");
+    }
+
+    const request = await ctx.table("clearRequests").getX(parsedRequestId);
+
+    const usersInChat = await ctx
+      .table("privateChats")
+      .getX(request.privateChatId)
+      .edge("users");
+
+    if (
+      !usersInChat.some((user) => user.clerkId === identity.tokenIdentifier)
+    ) {
+      throw new ConvexError(
+        "UNAUTHORIZED REQUEST: User tried to reject a clear request in a chat in which he is not in.",
+      );
+    }
+
+    if ((await request.edge("user")).clerkId === identity.tokenIdentifier) {
+      throw new ConvexError(
+        "UNAUTHORIZED REQUEST: User tried to reject his own clear request.",
+      );
+    }
+
+    await request.patch({
+      status: "rejected",
+    });
+  },
+});
+
+export const acceptClearRequest = mutation({
+  args: { requestId: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+
+    if (identity === null) {
+      console.error("Unauthenticated call to mutation");
+      return null;
+    }
+
+    const parsedRequestId = ctx
+      .table("clearRequests")
+      .normalizeId(args.requestId);
+
+    if (!parsedRequestId) {
+      throw new ConvexError("requestId was invalid");
+    }
+
+    const request = await ctx.table("clearRequests").getX(parsedRequestId);
+
+    const usersInChat = await ctx
+      .table("privateChats")
+      .getX(request.privateChatId)
+      .edge("users");
+
+    if (
+      !usersInChat.some((user) => user.clerkId === identity.tokenIdentifier)
+    ) {
+      throw new ConvexError(
+        "UNAUTHORIZED REQUEST: User tried to accept a clear request in a chat in which he is not in.",
+      );
+    }
+
+    if ((await request.edge("user")).clerkId === identity.tokenIdentifier) {
+      throw new ConvexError(
+        "UNAUTHORIZED REQUEST: User tried to accept his own clear request.",
+      );
+    }
+
+    const chat = ctx.table("privateChats").getX(request.privateChatId);
+    const messagesInChat = await chat.edge("messages");
+    const requestsInChat = await chat.edge("clearRequests");
+
+    for (const message of messagesInChat) {
+      await message.delete();
+    }
+
+    for (const request of requestsInChat) {
+      await request.delete();
+    }
+  },
+});
+
+export const expirePendingRequests = internalMutation({
+  handler: async (ctx) => {
+    for (const q1 of await ctx
+      .table("clearRequests", "by_creation_time", (q) =>
+        q.lte("_creationTime", Date.now() - 24 * 60 * 60 * 1000),
+      )
+      .filter((q) => q.eq(q.field("status"), "pending"))) {
+      if (q1) {
+        await q1.patch({
+          status: "expired",
+        });
+      }
+    }
+  },
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,12 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.interval(
+  "expire open requests",
+  { minutes: 1 },
+  internal.clearRequests.expirePendingRequests,
+);
+
+export default crons;

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,5 +1,6 @@
 import { mutation, query } from "./lib/functions";
-import { ConvexError, v } from "convex/values";
+import { ConvexError, type Infer, v } from "convex/values";
+import { type status } from "./schema";
 
 export const getMessages = query({
   args: { chatId: v.string() },
@@ -29,63 +30,28 @@ export const getMessages = query({
       );
     }
 
-    return chat.edge("messages").map(async (message) => ({
+    const messages = await chat.edge("messages").map(async (message) => ({
       ...message,
       userId: undefined,
+      type: "message" as const,
       from: await ctx.table("users").getX(message.userId),
       readBy: await message.edge("readBy"),
       sent: true,
     }));
-  },
-});
 
-export const createDeleteRequest = mutation({
-  args: { chatId: v.string() },
-  handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const requests = await chat.edge("clearRequests").map(async (request) => ({
+      ...request,
+      userId: undefined,
+      status: undefined,
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- ESLint rule is broken
+      type: `${request.status}Request` as `${Infer<typeof status>}Request`,
+      from: await ctx.table("users").getX(request.userId),
+      sent: true,
+    }));
 
-    if (identity === null) {
-      console.error("Unauthenticated call to mutation");
-      return null;
-    }
-
-    const convexUser = await ctx
-      .table("users")
-      .get("clerkId", identity.tokenIdentifier);
-
-    const parsedChatId = ctx.table("privateChats").normalizeId(args.chatId);
-
-    if (!parsedChatId) {
-      throw new ConvexError("chatId was invalid");
-    }
-
-    if (!convexUser) {
-      throw new ConvexError(
-        "Mismatch between Clerk and Convex. This is an error by us.",
-      );
-    }
-
-    const usersInChat = await ctx
-      .table("privateChats")
-      .getX(parsedChatId)
-      .edge("users");
-
-    if (
-      !usersInChat.some((user) => user.clerkId === identity.tokenIdentifier)
-    ) {
-      throw new ConvexError(
-        "UNAUTHORIZED REQUEST: User tried to send a message in a chat in which he is not in.",
-      );
-    }
-
-    await ctx.table("messages").insert({
-      userId: convexUser._id,
-      privateChatId: parsedChatId,
-      content: "",
-      type: "request",
-      deleted: false,
-      readBy: [convexUser._id],
-    });
+    return [...messages, ...requests].sort(
+      (a, b) => a._creationTime - b._creationTime,
+    );
   },
 });
 
@@ -134,58 +100,8 @@ export const createMessage = mutation({
       userId: convexUser._id,
       privateChatId: parsedChatId,
       content: args.content.trim(),
-      type: "message",
       deleted: false,
       readBy: [convexUser._id],
-    });
-  },
-});
-
-export const deleteAllMessagesInChat = mutation({
-  args: { chatId: v.string() },
-  handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-
-    if (identity === null) {
-      console.error("Unauthenticated call to mutation");
-      return null;
-    }
-
-    const parsedChatId = ctx.table("privateChats").normalizeId(args.chatId);
-
-    if (!parsedChatId) {
-      throw new ConvexError("chatId was invalid");
-    }
-
-    const chat = ctx.table("privateChats").getX(parsedChatId);
-    const messagesInChat = await chat.edge("messages");
-
-    for (const message of messagesInChat) {
-      await message.delete();
-    }
-  },
-});
-
-export const rejectRequest = mutation({
-  args: { messageId: v.string(), chatId: v.string() },
-  handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-
-    if (identity === null) {
-      console.error("Unauthenticated call to mutation");
-      return null;
-    }
-
-    const parsedMessageId = ctx.table("messages").normalizeId(args.messageId);
-
-    if (!parsedMessageId) {
-      throw new ConvexError("chatId was invalid");
-    }
-
-    const message = await ctx.table("messages").getX(parsedMessageId);
-
-    await message.patch({
-      type: "rejected",
     });
   },
 });

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -43,8 +43,7 @@ export const getMessages = query({
       ...request,
       userId: undefined,
       status: undefined,
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- ESLint rule is broken
-      type: `${request.status}Request` as `${Infer<typeof status>}Request`,
+      type: `${request.status}Request` satisfies `${Infer<typeof status>}Request`,
       from: await ctx.table("users").getX(request.userId),
       sent: true,
     }));

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,6 +1,5 @@
 import { mutation, query } from "./lib/functions";
-import { ConvexError, type Infer, v } from "convex/values";
-import { type status } from "./schema";
+import { ConvexError, v } from "convex/values";
 
 export const getMessages = query({
   args: { chatId: v.string() },
@@ -43,7 +42,7 @@ export const getMessages = query({
       ...request,
       userId: undefined,
       status: undefined,
-      type: `${request.status}Request` satisfies `${Infer<typeof status>}Request`,
+      type: `${request.status}Request` as const,
       from: await ctx.table("users").getX(request.userId),
       sent: true,
     }));

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,11 +1,18 @@
 import { defineEnt, defineEntSchema, getEntDefinitions } from "convex-ents";
 import { v } from "convex/values";
 
+export const status = v.union(
+  v.literal("pending"),
+  v.literal("rejected"),
+  v.literal("expired"),
+);
+
 const schema = defineEntSchema({
   privateChats: defineEnt({})
     .field("support", v.boolean(), { default: false })
     .edges("users")
-    .edges("messages", { ref: true }),
+    .edges("messages", { ref: true })
+    .edges("clearRequests", { ref: true }),
 
   users: defineEnt({})
     .field("clerkId", v.string(), { unique: true })
@@ -15,15 +22,20 @@ const schema = defineEntSchema({
     .field("lastName", v.optional(v.string()))
     .edges("privateChats")
     .edges("messages", { ref: true })
+    .edges("clearRequests", { ref: true })
     .edges("readMessages", {
       to: "messages",
       inverseField: "readBy",
       table: "readMessages",
     }),
 
+  clearRequests: defineEnt({})
+    .field("status", status)
+    .edge("user")
+    .edge("privateChat"),
+
   messages: defineEnt({})
     .field("content", v.string())
-    .field("type", v.string(), { default: "message" })
     .field("deleted", v.boolean(), { default: false })
     .edge("privateChat")
     .edge("user")

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,12 +1,6 @@
 import { defineEnt, defineEntSchema, getEntDefinitions } from "convex-ents";
 import { v } from "convex/values";
 
-export const status = v.union(
-  v.literal("pending"),
-  v.literal("rejected"),
-  v.literal("expired"),
-);
-
 const schema = defineEntSchema({
   privateChats: defineEnt({})
     .field("support", v.boolean(), { default: false })
@@ -30,7 +24,14 @@ const schema = defineEntSchema({
     }),
 
   clearRequests: defineEnt({})
-    .field("status", status)
+    .field(
+      "status",
+      v.union(
+        v.literal("pending"),
+        v.literal("rejected"),
+        v.literal("expired"),
+      ),
+    )
     .edge("user")
     .edge("privateChat"),
 

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -14,7 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "isolatedModules": true,
     "skipLibCheck": true,
     "noEmit": true

--- a/src/app/(internal-sites)/chats/[chatId]/page.tsx
+++ b/src/app/(internal-sites)/chats/[chatId]/page.tsx
@@ -211,10 +211,10 @@ export default function Page(props: { params: Promise<{ chatId: string }> }) {
     scrollToBottom(true);
   }
 
-  const createDeleteRequest = useMutation(api.messages.createDeleteRequest);
+  const createClearRequest = useMutation(api.clearRequests.createClearRequest);
 
-  const createMessageRequestHandler = (chatId: string) => async () => {
-    await createDeleteRequest({ chatId });
+  const createClearRequestHandler = (chatId: string) => async () => {
+    await createClearRequest({ chatId });
   };
 
   const [menuActive, setMenuActive] = useState(false);
@@ -248,7 +248,7 @@ export default function Page(props: { params: Promise<{ chatId: string }> }) {
           className="relative flex flex-col"
         >
           <DevMode className="top-20 z-10">
-            <button onClick={createMessageRequestHandler(params.chatId)}>
+            <button onClick={createClearRequestHandler(params.chatId)}>
               Delete Chat Request
             </button>
             <p>chatId: {params.chatId}</p>

--- a/src/app/(internal-sites)/chats/[chatId]/page.tsx
+++ b/src/app/(internal-sites)/chats/[chatId]/page.tsx
@@ -265,7 +265,7 @@ export default function Page(props: { params: Promise<{ chatId: string }> }) {
         >
           <DevMode className="top-20 z-10">
             <button onClick={createClearRequestHandler(params.chatId)}>
-              Delete Chat Request
+              Clear Chat Request
             </button>
             <p>chatId: {params.chatId}</p>
             <div onClick={() => devMode$.set(false)}>Disable dev mode</div>

--- a/src/components/chat-overview.tsx
+++ b/src/components/chat-overview.tsx
@@ -111,28 +111,53 @@ const Chats: React.FC<{
                           <Badge>Support</Badge>
                         </div>
                         <div className="ml-4 mt-0.5 text-sm text-destructive-foreground">
-                          {chat.lastMessage?.content != "" ? (
-                            chat.lastMessage?.content != undefined ? (
-                              chat.lastMessage?.readBy.some(
-                                (user) =>
-                                  user.username === clerkUser.user?.username,
-                              ) ? (
-                                chat.lastMessage.content
+                          {chat.lastMessage &&
+                            chat.lastMessage.type != "message" && (
+                              <div className="font-semibold text-destructive-foreground">
+                                {chat.lastMessage.type === "pendingRequest"
+                                  ? chat.lastMessage.clerkId
+                                      .split("|")
+                                      .pop() === clerkUser.user?.id
+                                    ? "You've sent a request to clear the chat"
+                                    : `The support has sent a request to clear the chat`
+                                  : chat.lastMessage?.type === "expiredRequest"
+                                    ? chat.lastMessage.clerkId
+                                        .split("|")
+                                        .pop() === clerkUser.user?.id
+                                      ? "Your request to clear the chat has expired"
+                                      : `The support's request to clear the chat has expired`
+                                    : chat.lastMessage.clerkId
+                                          .split("|")
+                                          .pop() === clerkUser.user?.username
+                                      ? "The support has rejected your request to clear the chat"
+                                      : "You have rejected the request to clear the chat"}
+                              </div>
+                            )}
+
+                          {chat.lastMessage ? (
+                            chat.lastMessage.type === "message" ? (
+                              chat.lastMessage.content != "" ? (
+                                chat.lastMessage.readBy.some(
+                                  (user) =>
+                                    user.username === clerkUser.user?.username,
+                                ) ? (
+                                  chat.lastMessage.content
+                                ) : (
+                                  <p className="truncate font-bold">
+                                    {chat.lastMessage.content}
+                                  </p>
+                                )
                               ) : (
-                                <p className="truncate font-bold">
-                                  {chat.lastMessage.content}
-                                </p>
+                                <div className="flex truncate">
+                                  <Ban className="p-1 pt-0" />
+                                  <p className="truncate">
+                                    This message was deleted
+                                  </p>
+                                </div>
                               )
-                            ) : (
-                              "No messages yet"
-                            )
+                            ) : null
                           ) : (
-                            <div className="flex truncate">
-                              <Ban className="p-1 pt-0" />
-                              <p className="truncate">
-                                This message was deleted
-                              </p>
-                            </div>
+                            "No messages yet"
                           )}
                         </div>
                       </div>
@@ -178,31 +203,57 @@ const Chats: React.FC<{
                           <div
                             className={cn(
                               "mt-0.5 w-10/12 truncate text-sm font-normal text-destructive-foreground",
-                              { "w-full": chat.lastMessage?.content == "" },
                             )}
                           >
-                            {chat.lastMessage?.content != "" ? (
-                              chat.lastMessage?.content != undefined ? (
-                                chat.lastMessage?.readBy.some(
-                                  (user) =>
-                                    user.username === clerkUser.user?.username,
-                                ) ? (
-                                  chat.lastMessage?.content
+                            {chat.lastMessage &&
+                              chat.lastMessage.type != "message" && (
+                                <div className="font-semibold text-destructive-foreground">
+                                  {chat.lastMessage.type === "pendingRequest"
+                                    ? chat.lastMessage.clerkId
+                                        .split("|")
+                                        .pop() === clerkUser.user?.id
+                                      ? "You've sent a request to clear the chat"
+                                      : `${chat.users[0].username} has sent a request to clear the chat`
+                                    : chat.lastMessage?.type ===
+                                        "expiredRequest"
+                                      ? chat.lastMessage.clerkId
+                                          .split("|")
+                                          .pop() === clerkUser.user?.id
+                                        ? "Your request to clear the chat has expired"
+                                        : `${chat.users[0].username}'s request to clear the chat has expired`
+                                      : chat.lastMessage.clerkId
+                                            .split("|")
+                                            .pop() === clerkUser.user?.username
+                                        ? `${chat.users[0].username} has rejected your request to clear the chat`
+                                        : "You have rejected the request to clear the chat"}
+                                </div>
+                              )}
+
+                            {chat.lastMessage ? (
+                              chat.lastMessage.type === "message" ? (
+                                chat.lastMessage.content != "" ? (
+                                  chat.lastMessage.readBy.some(
+                                    (user) =>
+                                      user.username ===
+                                      clerkUser.user?.username,
+                                  ) ? (
+                                    chat.lastMessage.content
+                                  ) : (
+                                    <p className="truncate font-bold">
+                                      {chat.lastMessage.content}
+                                    </p>
+                                  )
                                 ) : (
-                                  <p className="truncate font-bold">
-                                    {chat.lastMessage?.content}
-                                  </p>
+                                  <div className="flex truncate">
+                                    <Ban className="p-1 pt-0" />
+                                    <p className="truncate">
+                                      This message was deleted
+                                    </p>
+                                  </div>
                                 )
-                              ) : (
-                                "No messages yet"
-                              )
+                              ) : null
                             ) : (
-                              <div className="flex truncate">
-                                <Ban className="p-1 pt-0" />
-                                <p className="truncate">
-                                  This message was deleted
-                                </p>
-                              </div>
+                              "No messages yet"
                             )}
                           </div>
                         </div>
@@ -215,28 +266,54 @@ const Chats: React.FC<{
                             <Badge>Tool</Badge>
                           </div>
                           <div className="mt-0.5 w-10/12 truncate text-sm font-normal text-destructive-foreground">
-                            {chat.lastMessage?.content != "" ? (
-                              chat.lastMessage?.content != undefined ? (
-                                chat.lastMessage?.readBy.some(
-                                  (user) =>
-                                    user.username === clerkUser.user?.username,
-                                ) ? (
-                                  chat.lastMessage.content
+                            {chat.lastMessage &&
+                              chat.lastMessage.type != "message" && (
+                                <div className="font-semibold text-destructive-foreground">
+                                  {chat.lastMessage.type === "pendingRequest"
+                                    ? chat.lastMessage.clerkId
+                                        .split("|")
+                                        .pop() === clerkUser.user?.id
+                                      ? "You've sent a request to clear the chat"
+                                      : `Your notes have sent a request to clear the chat`
+                                    : chat.lastMessage?.type ===
+                                        "expiredRequest"
+                                      ? chat.lastMessage.clerkId
+                                          .split("|")
+                                          .pop() === clerkUser.user?.id
+                                        ? "Your request to clear the chat has expired"
+                                        : `Your notes' request to clear the chat has expired`
+                                      : chat.lastMessage.clerkId
+                                            .split("|")
+                                            .pop() === clerkUser.user?.username
+                                        ? "Your notes have rejected your request to clear the chat"
+                                        : "You have rejected the request to clear the chat"}
+                                </div>
+                              )}
+                            {chat.lastMessage ? (
+                              chat.lastMessage.type === "message" ? (
+                                chat.lastMessage.content != "" ? (
+                                  chat.lastMessage.readBy.some(
+                                    (user) =>
+                                      user.username ===
+                                      clerkUser.user?.username,
+                                  ) ? (
+                                    chat.lastMessage.content
+                                  ) : (
+                                    <p className="truncate font-bold">
+                                      {chat.lastMessage.content}
+                                    </p>
+                                  )
                                 ) : (
-                                  <p className="truncate font-bold">
-                                    {chat.lastMessage.content}
-                                  </p>
+                                  <div className="flex truncate">
+                                    <Ban className="p-1 pt-0" />
+                                    <p className="truncate">
+                                      This message was deleted
+                                    </p>
+                                  </div>
                                 )
-                              ) : (
-                                "No messages yet"
-                              )
+                              ) : null
                             ) : (
-                              <div className="flex truncate">
-                                <Ban className="p-1 pt-0" />
-                                <p className="truncate">
-                                  This message was deleted
-                                </p>
-                              </div>
+                              "No messages yet"
                             )}
                           </div>
                         </div>
@@ -244,22 +321,10 @@ const Chats: React.FC<{
                     </div>
                   </div>
                   <div className="flex">
-                    {chat.lastMessage?.content != "" ? (
-                      chat.lastMessage?.content != undefined ? (
-                        chat.lastMessage?.readBy.some(
-                          (user) => user.username === clerkUser.user?.username,
-                        ) ? (
-                          ""
-                        ) : (
-                          <div className="flex h-6 w-9 items-center justify-center rounded-full bg-accent p-1 text-[70%] font-medium">
-                            {chat.numberOfUnreadMessages}
-                          </div>
-                        )
-                      ) : (
-                        ""
-                      )
-                    ) : (
-                      ""
+                    {chat.numberOfUnreadMessages > 0 && (
+                      <div className="flex h-6 w-9 items-center justify-center rounded-full bg-accent p-1 text-[70%] font-medium">
+                        {chat.numberOfUnreadMessages}
+                      </div>
                     )}
                     <ArrowRight className="!important ml-3 h-6 w-6 text-secondary-foreground lg:mr-10" />
                   </div>

--- a/src/components/chat-overview.tsx
+++ b/src/components/chat-overview.tsx
@@ -110,7 +110,7 @@ const Chats: React.FC<{
                           </div>
                           <Badge>Support</Badge>
                         </div>
-                        <p className="ml-4 mt-0.5 text-sm text-destructive-foreground">
+                        <div className="ml-4 mt-0.5 text-sm text-destructive-foreground">
                           {chat.lastMessage?.content != "" ? (
                             chat.lastMessage?.content != undefined ? (
                               chat.lastMessage?.readBy.some(
@@ -134,7 +134,7 @@ const Chats: React.FC<{
                               </p>
                             </div>
                           )}
-                        </p>
+                        </div>
                       </div>
                     </div>
                     <ArrowRight className="ml-3 text-secondary-foreground lg:mr-10" />
@@ -175,7 +175,7 @@ const Chats: React.FC<{
                           <p className="truncate text-lg">
                             {chat.users[0].username}
                           </p>
-                          <p
+                          <div
                             className={cn(
                               "mt-0.5 w-10/12 truncate text-sm font-normal text-destructive-foreground",
                               { "w-full": chat.lastMessage?.content == "" },
@@ -204,7 +204,7 @@ const Chats: React.FC<{
                                 </p>
                               </div>
                             )}
-                          </p>
+                          </div>
                         </div>
                       ) : (
                         <div className="flex flex-col">
@@ -214,7 +214,7 @@ const Chats: React.FC<{
                             </p>
                             <Badge>Tool</Badge>
                           </div>
-                          <p className="mt-0.5 w-10/12 truncate text-sm font-normal text-destructive-foreground">
+                          <div className="mt-0.5 w-10/12 truncate text-sm font-normal text-destructive-foreground">
                             {chat.lastMessage?.content != "" ? (
                               chat.lastMessage?.content != undefined ? (
                                 chat.lastMessage?.readBy.some(
@@ -238,7 +238,7 @@ const Chats: React.FC<{
                                 </p>
                               </div>
                             )}
-                          </p>
+                          </div>
                         </div>
                       )}
                     </div>

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -360,9 +360,9 @@ export const Message = ({
                   <p>
                     {message.type === "pendingRequest"
                       ? chatInfo.data?.otherUser[0]?.username +
-                        " has sent a request to delete the chat"
+                        " has sent a request to clear the chat"
                       : message.type === "expiredRequest"
-                        ? `The request of ${chatInfo.data?.otherUser[0]?.username + " to delete the chat"} has expired`
+                        ? `The request of ${chatInfo.data?.otherUser[0]?.username + " to clear the chat"} has expired`
                         : "You have rejected the request to clear the chat"}
                   </p>
                   <div className="flex justify-between">

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -150,17 +150,14 @@ export const Message = ({
   };
 
   useEffect(() => {
-    if (inView && message.sent && message.type == "message") {
-      void markRead({ messageId: message._id });
-    }
-  }, [
-    inView,
-    message._id,
-    deleteMessage,
-    message.sent,
-    markRead,
-    message.type,
-  ]);
+    const markMessageAsRead = async () => {
+      if (inView && message.sent && message.type == "message") {
+        await markRead({ messageId: message._id });
+      }
+    };
+
+    void markMessageAsRead();
+  }, [inView, markRead, message._id, message.sent, message.type]);
 
   const sentInfo = () => {
     return (

--- a/src/components/message.tsx
+++ b/src/components/message.tsx
@@ -128,36 +128,38 @@ export const Message = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const markRead = useMutation(api.messages.markMessageRead);
 
-  const deleteAllMessagesInChat = useMutation(
-    api.messages.deleteAllMessagesInChat,
-  );
+  const acceptClearRequest = useMutation(api.clearRequests.acceptClearRequest);
 
   const chatInfo = useQueryWithStatus(api.chats.getChatInfoFromId, {
     chatId: message.privateChatId,
   });
 
-  const rejectRequest = useMutation(api.messages.rejectRequest);
+  const rejectClearRequest = useMutation(api.clearRequests.rejectClearRequest);
 
-  const rejectRequestHandler =
-    (chatId: string, messageId: string) => async () => {
-      await rejectRequest({ chatId, messageId });
+  const rejectClearRequestHandler =
+    (chatId: string, requestId: string) => async () => {
+      await rejectClearRequest({ chatId, requestId });
     };
 
-  const deleteAllMessagesinChat = (chatId: string) => async () => {
-    await deleteAllMessagesInChat({ chatId });
+  const acceptClearRequestHandler = (requestId: string) => async () => {
+    if (message.type == "pendingRequest") {
+      await acceptClearRequest({ requestId });
+    } else {
+      console.error("Error");
+    }
   };
 
   useEffect(() => {
-    if (inView && message.sent) {
+    if (inView && message.sent && message.type == "message") {
       void markRead({ messageId: message._id });
     }
   }, [
     inView,
     message._id,
-    message.deleted,
     deleteMessage,
     message.sent,
     markRead,
+    message.type,
   ]);
 
   const sentInfo = () => {
@@ -196,13 +198,14 @@ export const Message = ({
             ref={refs.setReference}
             className={cn("my-1 mr-4 flex w-full flex-col items-end", {
               "mr-0 items-center":
-                message.type == "request" || message.type == "rejected",
+                message.type == "pendingRequest" ||
+                message.type == "rejectedRequest",
             })}
           >
             <div
               onContextMenu={(e) => {
                 e.preventDefault();
-                if (message.deleted) return;
+                if (message.type === "message" && message.deleted) return;
                 checkClickPosition(e);
                 setIsModalOpen(!isModalOpen);
                 setSelectedMessageId(message._id);
@@ -210,7 +213,7 @@ export const Message = ({
               }}
               onClick={(e) => {
                 if (!isMobile) return;
-                if (message.deleted) return;
+                if (message.type === "message" && message.deleted) return;
                 checkClickPosition(e);
                 setIsModalOpen(!isModalOpen);
                 setSelectedMessageId(message._id);
@@ -221,11 +224,12 @@ export const Message = ({
                 {
                   "sticky z-50 opacity-100": message._id === selectedMessageId,
                   "my-2 max-w-[80%] border-2 border-secondary bg-primary":
-                    message.type == "request" || message.type == "rejected",
+                    message.type == "pendingRequest" ||
+                    message.type == "rejectedRequest",
                 },
               )}
             >
-              {message.deleted ? (
+              {message.type === "message" && message.deleted ? (
                 <div className="flex font-medium">
                   <Ban />
                   <p className="ml-2.5">This message was deleted</p>
@@ -234,10 +238,12 @@ export const Message = ({
                 <div>
                   {message.type != "message" ? (
                     <div className="font-semibold text-destructive-foreground">
-                      {message.type == "request"
-                        ? "You've sent a request"
-                        : chatInfo.data?.otherUser[0]?.username +
-                          " has rejected the request"}
+                      {message.type === "pendingRequest"
+                        ? "You've sent a request to clear the chat"
+                        : message.type === "expiredRequest"
+                          ? "Your request to clear the chat has expired"
+                          : chatInfo.data?.otherUser[0]?.username +
+                            " has rejected the request to clear the chat"}
                     </div>
                   ) : (
                     <div>{message.content}</div>
@@ -246,7 +252,7 @@ export const Message = ({
               )}
             </div>
             <div className="mr-2 text-[75%] font-bold text-secondary-foreground">
-              {!message.deleted && message.type == "message"
+              {message.type == "message" && !message.deleted
                 ? message.readBy
                   ? message.readBy.map((user) => {
                       if (user.username != clerkUser.user?.username) {
@@ -315,14 +321,15 @@ export const Message = ({
           <div
             className={cn("my-1 ml-4 flex w-full justify-start", {
               "ml-0 justify-center":
-                message.type == "request" || message.type == "rejected",
+                message.type === "pendingRequest" ||
+                message.type === "rejectedRequest",
             })}
           >
             <div
               ref={refs.setReference}
               onContextMenu={(e) => {
                 e.preventDefault();
-                if (message.deleted) return;
+                if (message.type === "message" && message.deleted) return;
                 checkClickPosition(e);
                 setIsModalOpen(!isModalOpen);
                 setSelectedMessageId(message._id);
@@ -330,7 +337,7 @@ export const Message = ({
               }}
               onClick={(e) => {
                 if (!isMobile) return;
-                if (message.deleted) return;
+                if (message.type === "message" && message.deleted) return;
                 checkClickPosition(e);
                 setIsModalOpen(!isModalOpen);
                 setSelectedMessageId(message._id);
@@ -341,11 +348,12 @@ export const Message = ({
                 {
                   "sticky z-50 opacity-100": message._id == selectedMessageId,
                   "my-2 max-w-[80%] border-2 border-secondary bg-primary":
-                    message.type == "request" || message.type == "rejected",
+                    message.type === "pendingRequest" ||
+                    message.type === "rejectedRequest",
                 },
               )}
             >
-              {message.deleted ? (
+              {message.type === "message" && message.deleted ? (
                 <div className="flex font-medium">
                   <Ban />
                   <p className="ml-2.5">This message was deleted</p>
@@ -353,25 +361,25 @@ export const Message = ({
               ) : message.type != "message" ? (
                 <div className="font-semibold text-destructive-foreground">
                   <p>
-                    {message.type == "request"
+                    {message.type === "pendingRequest"
                       ? chatInfo.data?.otherUser[0]?.username +
-                        " has send a delete Chat request"
-                      : "You has rejected the request"}
+                        " has sent a request to delete the chat"
+                      : message.type === "expiredRequest"
+                        ? `The request of ${chatInfo.data?.otherUser[0]?.username + " to delete the chat"} has expired`
+                        : "You have rejected the request to clear the chat"}
                   </p>
                   <div className="flex justify-between">
-                    {message.type == "request" ? (
+                    {message.type === "pendingRequest" ? (
                       <>
                         <button
-                          onClick={deleteAllMessagesinChat(
-                            message.privateChatId,
-                          )}
+                          onClick={acceptClearRequestHandler(message._id)}
                           className="mt-4 flex rounded-sm bg-accept p-2 px-4"
                         >
                           <CircleCheck className="mr-1 p-0.5" />
                           <p>Accept</p>
                         </button>
                         <button
-                          onClick={rejectRequestHandler(
+                          onClick={rejectClearRequestHandler(
                             message.privateChatId,
                             message._id,
                           )}


### PR DESCRIPTION
Rework of #425 

- Expires all requests older than a day
- Only one open request at a time
- Validation if a user is allowed to accept a request to clear the chat

Another problem this PR is fixing is this:
<img width="990" alt="image" src="https://github.com/user-attachments/assets/088483eb-58e7-4673-81c2-ae076d25d51f">

- closes #389 

The problem was that our old technique overate database bandwidth as it goes through all messages and not only through the requests. The solution is to make a new table only for requests and merge requests and messages in the getMessages queries. I used the automatically set up index by `_creationTime`.